### PR TITLE
Remove deleted file: examples/attributes.pl from MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2,7 +2,6 @@ bin/color_matrix
 bin/colored_dmesg
 bin/show_all_colors
 bin/uncolor
-examples/attributes.pl
 examples/fall_through_attributes.pl
 lib/Term/ExtendedColor.pm
 Makefile.PL


### PR DESCRIPTION
This will remove:

Warning: the following files are missing in your kit:
    examples/attributes.pl

When running:
        perl Makefile.PL
