### PR TITLE
uncolor fix

### DIFF
--- a/lib/Term/ExtendedColor.pm
+++ b/lib/Term/ExtendedColor.pm
@@ -529,7 +529,8 @@ sub uncolor {
   return if !@data;
 
   if(ref($data[0]) eq 'ARRAY') {
-    push(@data, @{$_[0]});
+    my $ref = shift @data;
+    push(@data, @{$ref});
   }
 
   for(@data) {

--- a/lib/Term/ExtendedColor.pm
+++ b/lib/Term/ExtendedColor.pm
@@ -693,6 +693,7 @@ Like C<fg()>, but sets background colors.
 
   my $stripped = uncolor($colored_data);
   my @no_color = uncolor(\@colored);
+  my @no_color = uncolor(@colored);
 
 Remove all attribute and color escape sequences from the input.
 

--- a/t/05-uncolor.t
+++ b/t/05-uncolor.t
@@ -1,10 +1,10 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 2;
+use Test::More tests => 4;
 use Term::ExtendedColor qw(uncolor get_colors);
 
-my(@colors, @attributes);
+my(@colors, @colors2, @attributes);
 
 my $j = 0;
 for(my $i = 0; $i< 17; ++$i) {
@@ -27,6 +27,7 @@ for(my $i = 0; $i<9; ++$i) {
   }
 }
 
+@colors2    = @colors;
 @colors     = uncolor(@colors);
 @attributes = uncolor(@attributes);
 
@@ -69,3 +70,6 @@ is($non_color,
   'uncolor does not remove non-color stuff'
 );
 
+is_deeply( [ uncolor(\@colors2) ], \@colors,     "uncolor: passing arrayref as first argument - list context");
+
+is       ( uncolor(\@colors2), join('',@colors), "uncolor: passing arrayref as first argument - scalar context");


### PR DESCRIPTION
uncolor stores all passed arguments in its lexical @data array. 

If the first element of @data is arraref, script will dereference it and push its data to the end of @data array, but will keep the arrayref as the first argument, which leads to bad output.

This fix makes sure that this arrayref is not kept in the @data.
